### PR TITLE
Update NSEnumerator.h

### DIFF
--- a/Headers/Foundation/NSEnumerator.h
+++ b/Headers/Foundation/NSEnumerator.h
@@ -42,7 +42,7 @@ typedef struct
   unsigned long	state;
   __unsafe_unretained id		*itemsPtr;
   unsigned long	*mutationsPtr;
-  unsigned long	extra[5];
+  uintptr_t	extra[5];
 } NSFastEnumerationState;
 
 @protocol NSFastEnumeration


### PR DESCRIPTION
Changed NSFastEnumerationState struct extra array from unsigned long to uintptr_t.  uintptr_t is consistently 64-bit in size across platforms.  unsigned long varies in size across platforms and was causing a pointer memory issue on the Windows platform.