### PR TITLE
Update GSAtomic.h

### DIFF
--- a/Source/GSAtomic.h
+++ b/Source/GSAtomic.h
@@ -13,7 +13,7 @@
 #define __has_extension(x) 0
 #endif
 
-#if __has_extension(c_atomic) || __has_extension(cxx_atomic)
+#if !defined(__OBJC__) && (__has_extension(c_atomic) || __has_extension(cxx_atomic))
 
 /*
  * Use native C11 atomic operations. _Atomic() should be defined by the


### PR DESCRIPTION
A preprocessor definition was modified for c_atomic and cxx_atomic extensions.  Without this modification, GNUstep libs-base does not build on Winsows.

This modification was tested on Windows with gcc and Ubuntu with clang and gcc.